### PR TITLE
Convox CLI Update

### DIFF
--- a/lib/kraken/resource.rb
+++ b/lib/kraken/resource.rb
@@ -54,7 +54,7 @@ class Option
     when :flag
       opt += "--#{@name}" if @value
     when :option
-      opt += "--#{@name} #{@value}" if @value
+      opt += "--#{@name}=#{@value}" if @value
     end
   end
 


### PR DESCRIPTION
The convox CLI was complaining with the spaces between the flags, and it ended up working with the equal sign in there.